### PR TITLE
Manual Production Deployment Pipeline

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -57,5 +57,5 @@ jobs:
                   git config user.email "syntax@bot.com"
                   sed -i -E "s/ghcr.io\/stamford-syntax-club\/stamfordcenter-backend.*$/ghcr.io\/stamford-syntax-club\/stamfordcenter-backend:${GITHUB_SHA}/" stamfordcenter/docker-compose.dev.yaml
                   git add stamfordcenter/docker-compose.dev.yaml
-                  git commit -m "🤖 change docker image version to ${GITHUB_SHA}"
+                  git commit -m "🤖 [CENTER-BACKEND-DEV] change docker image version to ${GITHUB_SHA}"
                   git push origin deploy/backend-${GITHUB_SHA}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -1,0 +1,46 @@
+name: Production Environment CI/CD
+
+on:
+    workflow_dispatch:
+        inputs:
+            approval:
+                description: "🔦 Backend Lead Approved"
+                required: true
+                type: boolean
+            acknowledge:
+                description: "📝 Infra Team acknowledged"
+                required: true
+                type: boolean
+            deploy-tag:
+                description: "🎯 Deploy docker tag"
+                required: true
+                type: string
+
+jobs:
+    gitops-prod:
+        runs-on: ubuntu-latest
+        steps:
+            - name: verify manual inputs
+              run: |
+                  { if [ '${{ inputs.approval }}' = 'false' ]; then echo "🔦 Backend Lead not approved yet"; exit 1; fi }
+                  { if [ '${{ inputs.acknowledge }}' = 'false' ]; then echo "📝 Infra Team not acknowledged yet"; exit 1; fi }
+
+            - name: checkout
+              uses: actions/checkout@v3
+              with:
+                  repository: stamford-syntax-club/infra
+                  fetch-depth: 0
+                  token: ${{ secrets.WORKFLOW_TOKEN }}
+
+            - name: create and checkout new branch
+              run: |
+                  git checkout -b deploy/prod/backend-${{ inputs.deploy-tag }}
+
+            - name: change prod image tag
+              run: |
+                  git config user.name "syntax-prod-bot"
+                  git config user.email "syntax-prod@bot.com"
+                  sed -i -E "s/ghcr.io\/stamford-syntax-club\/stamfordcenter-backend.*$/ghcr.io\/stamford-syntax-club\/stamfordcenter-backend:${{ inputs.deploy-tag }}/" stamfordcenter/docker-compose.prod.yaml
+                  git add stamfordcenter/docker-compose.prod.yaml
+                  git commit -m "🤖 [CENTER-BACKEND-PROD] change docker image version to ${{ inputs.deploy-tag }}"
+                  git push origin deploy/prod/backend-${{ inputs.deploy-tag }}


### PR DESCRIPTION
Pipeline can be triggered in [Actions](https://github.com/stamford-syntax-club/stamfordcenter-backend/actions)
** note that it won't show up yet because the action page points to the main branch


![Screenshot 2566-10-24 at 16 00 37](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/fee2a682-d057-4484-ace7-9d447e5797d1)


## Result:
The pipeline: 
1. goes to infra repo
2. changes image tag in `stamfordcenter/docker-compose.prod.yaml`
3. pushes to branch `deploy/prod/backend-<IMAGE-TAG-THAT-WE-PUT-IN>` 
  3.1. this will trigger the CI pipeline in infra to create a deployment pull request

![image](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/113dfe7e-cc0d-4e83-9a84-3fee9da8bd96)

example: https://github.com/stamford-syntax-club/infra/pull/70/files