### PR TITLE
improvement: change from NODE_ENV to APP_ENV to determine environment

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,11 +1,11 @@
 export const BASE_URL: string = (() => {
-	switch (process.env.NODE_ENV) {
+	switch (process.env.APP_ENV) {
 		case "production":
 			return "https://center-be.stamford.dev";
 		case "beta":
 			return "https://center-be-beta.stamford.dev";
 		default:
-			console.warn(`Unexpected NODE_ENV value: ${process.env.NODE_ENV}. Falling back to localhost.`);
+			console.warn(`Unexpected APP_ENV value: ${process.env.APP_ENV}. Falling back to localhost.`);
 			return `http://localhost:${process.env.PORT}`;
 	}
 })();

--- a/test/unit/constants.test.ts
+++ b/test/unit/constants.test.ts
@@ -5,9 +5,9 @@ describe("BASE URL when", () => {
 		jest.resetModules(); // Reset modules to clear cached values
 	});
 
-	describe("NODE_ENV = production", () => {
+	describe("APP_ENV = production", () => {
 		it("should return the production host URL", () => {
-			process.env.NODE_ENV = "production";
+			process.env.APP_ENV = "production";
 
 			const BASE_URL = require("@utils/constants").BASE_URL;
 
@@ -15,9 +15,9 @@ describe("BASE URL when", () => {
 		});
 	});
 
-	describe("NODE_ENV = beta", () => {
+	describe("APP_ENV = beta", () => {
 		it("should return the beta host URL", () => {
-			process.env.NODE_ENV = "beta";
+			process.env.APP_ENV = "beta";
 
 			const BASE_URL = require("@utils/constants").BASE_URL;
 
@@ -27,7 +27,7 @@ describe("BASE URL when", () => {
 
 	describe("default case", () => {
 		it("should return the localhost URL with the correct port", () => {
-			process.env.NODE_ENV = "local";
+			process.env.APP_ENV = "local";
 			process.env.PORT = "8080";
 
 			const BASE_URL = require("@utils/constants").BASE_URL;


### PR DESCRIPTION
closes https://github.com/stamford-syntax-club/stamfordcenter-backend/issues/26

### Changes in Infra Repo
Before this change can be deployed, infra team MUST:
- [x] add environment `APP_ENV=beta` to `stamfordcenter/docker-compose.dev.yaml` (+remove the old `NODE_ENV` one)
- [x] add environment `APP_ENV=production` to `stamfordcenter/docker-compose.prod.yaml`