### PR TITLE
improvement: optimize image size & add cache for building new images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+coverage
+node_modules

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -31,6 +31,10 @@ jobs:
                   password: ${{secrets.GITHUB_TOKEN}}
                   logout: true
 
+            - name: Create Docker Cacha Storage Backend
+              run: |
+                  docker buildx create --use --driver=docker-container
+
             - name: Build and Push to GitHub Container Registry
               uses: docker/build-push-action@v3.2.0
               with:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -38,8 +38,8 @@ jobs:
                   tags: |
                       ghcr.io/stamford-syntax-club/stamfordcenter-backend:${{ env.GITHUB_SHA }}
                   push: true
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+                  cache-from: type=registry,ref=ghcr.io/stamford-syntax-club/stamfordcenter-backend
+                  cache-to: type=registry,ref=ghcr.io/stamford-syntax-club/stamfordcenter-backend
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -2,7 +2,7 @@ name: Dev Environment CI/CD
 
 on:
     push:
-        branches: [main, khing/optimize/pipeline]
+        branches: [main]
 
 jobs:
     build-and-push:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -42,8 +42,8 @@ jobs:
                   tags: |
                       ghcr.io/stamford-syntax-club/stamfordcenter-backend:${{ env.GITHUB_SHA }}
                   push: true
-                  cache-from: type=registry,ref=ghcr.io/stamford-syntax-club/stamfordcenter-backend
-                  cache-to: type=registry,ref=ghcr.io/stamford-syntax-club/stamfordcenter-backend
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -2,7 +2,7 @@ name: Dev Environment CI/CD
 
 on:
     push:
-        branches: [main]
+        branches: [main, khing/optimize/pipeline]
 
 jobs:
     build-and-push:
@@ -16,6 +16,12 @@ jobs:
 
             - name: Setup SHA
               run: echo "GITHUB_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+
+            - name: Setup Node JS
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+                  cache: npm
 
             - name: Login ghcr.io
               uses: docker/login-action@v2.1.0
@@ -32,6 +38,8 @@ jobs:
                   tags: |
                       ghcr.io/stamford-syntax-club/stamfordcenter-backend:${{ env.GITHUB_SHA }}
                   push: true
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build Stage ----
-FROM node:alpine AS builder
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build
 
 # ---- Production Stage ----
-FROM node:alpine
+FROM node:18-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM node:alpine AS builder
 
 WORKDIR /app
 
-COPY package.json ./
+COPY package.json package-lock.json ./
 
 # Setting environment variable to development to install all dependencies
 ENV NODE_ENV=development
 
-RUN npm install
+# Install exactly as described in package-lock.json without any additional modifications - ensure predictable and stable environment
+RUN npm ci 
 
 COPY . .
 
@@ -24,10 +25,10 @@ ENV NODE_ENV=production
 
 # Copy only the built code and package.json
 COPY --from=builder /app/dist ./dist
-COPY package.json ./
+COPY --from=builder /app/package.json /app/package-lock.json ./
 
 # Install only production dependencies
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 EXPOSE 8080
 


### PR DESCRIPTION
## What I have done in this PR
- Replace `npm install` with `npm ci` which essentially installs dependencies based from package-lock.json without modifying it, ensuring the image built does not contain any unexpected stuff

- Explicitly declare node alpine version to ensure consistent build

- Use GitHub Action Cache to store build caches.

## Result

- Image size reduces from 340MB to 270MB  ~20% improvement
![image](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/ae7136e2-bf1e-4be1-ae43-6c6253f26d31)
![image](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/74dd9c96-5b12-4fb6-8d30-6f7c4f703de2)

- Image build time reduces from 1 minute 30 seconds to 40 seconds ~50% improvement
![image](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/dac664d6-4ad3-44d9-835a-93043497e4fc)
![image](https://github.com/stamford-syntax-club/stamfordcenter-backend/assets/92321280/d49599f7-4feb-4fa9-95fc-bade9ac5172e)


## References
https://www.linkedin.com/pulse/using-github-actions-caches-docker-builds-mikalai-ivanisenka/
https://docs.docker.com/build/cache/backends/
https://github.com/thinc-org/cugetreg/blob/beta/.github/workflows/reusable-ci.yaml#L30